### PR TITLE
Ably PHP laravel broadcaster + github CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.idea
+.DS_Store
+/composer.lock
+/.phpunit.result.cache
+/vendor/
+.*.swp

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# Ably Broadcaster for Laravel

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,50 @@
+{
+    "name": "ably/laravel-broadcaster",
+    "description": "An Ably broadcaster for Laravel",
+    "keywords": [
+        "ably",
+        "laravel-broadcaster"
+    ],
+    "homepage": "https://github.com/ably/laravel-broadcaster",
+    "license": "Apache-2.0",
+    "type": "library",
+    "authors": [
+        {
+            "name": "Ably",
+            "email": "support@ably.io"
+        }
+    ],
+    "require": {
+        "php": "^7.2 || ^8.0",
+        "ably/ably-php": "^1.1",
+        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "ext-json" : "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^8.5 || ^9.5",
+        "orchestra/testbench": "4.*"
+    },
+    "autoload": {
+        "psr-4": {
+            "Ably\\LaravelBroadcaster\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Ably\\LaravelBroadcaster\\Tests\\": "tests"
+        }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Ably\\LaravelBroadcaster\\LaravelAblyBroadcasterServiceProvider"
+            ]
+        }
+    }
+}

--- a/src/AblyBroadcaster.php
+++ b/src/AblyBroadcaster.php
@@ -1,0 +1,340 @@
+<?php
+
+namespace Ably\LaravelBroadcaster;
+
+use Ably\AblyRest;
+use Ably\Exceptions\AblyException;
+use Ably\Models\Message as AblyMessage;
+use Illuminate\Broadcasting\Broadcasters\Broadcaster;
+use Illuminate\Broadcasting\BroadcastException;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+class AblyBroadcaster extends Broadcaster
+{
+    /**
+     * The AblyRest SDK instance.
+     *
+     * @var \Ably\AblyRest
+     */
+    protected $ably;
+
+    /**
+     * Used for setting expiry of issues tokens.
+     *
+     * @var int|mixed
+     * @default 1 hr
+     */
+    private $tokenExpiry = 3600;
+
+    /**
+     * Default channel capabilities, all public channels are by default given subscribe, history and channel-metadata access
+     * Set as per https://ably.com/docs/core-features/authentication#capability-operations.
+     *
+     * @var array
+     */
+    private $defaultChannelClaims = [
+        'public:*' => ['subscribe', 'history', 'channel-metadata'],
+    ];
+
+    /**
+     * Create a new broadcaster instance.
+     *
+     * @param  \Ably\AblyRest  $ably
+     * @param  array  $config
+     * @return void
+     */
+    public function __construct(AblyRest $ably, $config)
+    {
+        $this->ably = $ably;
+        if (self::$serverTimeDiff == null) {
+            self::setServerTime(round($this->ably->time() / 1000));
+        }
+        if (array_key_exists('disable_public_channels', $config) && $config['disable_public_channels']) {
+            $this->defaultChannelClaims = ['public:*' => ['channel-metadata']];
+        }
+        if (array_key_exists('token_expiry', $config)) {
+            $this->tokenExpiry = $config['token_expiry'];
+        }
+    }
+
+    private static $serverTimeDiff = null;
+
+    /**
+     * @param  int  $time
+     * @return void
+     */
+    private static function setServerTime($time)
+    {
+        self::$serverTimeDiff = time() - $time;
+    }
+
+    /**
+     * @return int
+     */
+    private static function getServerTime()
+    {
+        if (self::$serverTimeDiff != null) {
+            return time() - self::$serverTimeDiff;
+        }
+
+        return time();
+    }
+
+    /**
+     * Get the public token value from the Ably key.
+     *
+     * @return mixed
+     */
+    protected function getPublicToken()
+    {
+        return Str::before($this->ably->options->key, ':');
+    }
+
+    /**
+     * Get the private token value from the Ably key.
+     *
+     * @return mixed
+     */
+    protected function getPrivateToken()
+    {
+        return Str::after($this->ably->options->key, ':');
+    }
+
+    /**
+     * Authenticate the incoming request for a given channel.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+     */
+    public function auth($request)
+    {
+        $channelName = $request->channel_name;
+        $token = $request->token;
+        $connectionId = $request->socket_id;
+        $normalizedChannelName = $this->normalizeChannelName($channelName);
+        $userId = null;
+        $channelCapability = ['*'];
+        $user = $this->retrieveUser($request, $normalizedChannelName);
+        if ($user) {
+            $userId = method_exists($user, 'getAuthIdentifierForBroadcasting')
+                ? $user->getAuthIdentifierForBroadcasting()
+                : $user->getAuthIdentifier();
+        }
+        if ($this->isGuardedChannel($channelName)) {
+            if (! $user) {
+                throw new AccessDeniedHttpException('User not authenticated, '.$this->stringify($channelName, $connectionId));
+            }
+            try {
+                $userChannelMetaData = parent::verifyUserCanAccessChannel($request, $normalizedChannelName);
+                if (is_array($userChannelMetaData) && array_key_exists('capability', $userChannelMetaData)) {
+                    $channelCapability = $userChannelMetaData['capability'];
+                    unset($userChannelMetaData['capability']);
+                }
+            } catch (\Exception $e) {
+                throw new AccessDeniedHttpException('Access denied, '.$this->stringify($channelName, $connectionId, $userId), $e);
+            }
+        }
+
+        try {
+            $signedToken = $this->getSignedToken($channelName, $token, $userId, $channelCapability);
+        } catch (\Exception $_) { // excluding exception to avoid exposing private key
+            throw new AccessDeniedHttpException('malformed token, '.$this->stringify($channelName, $connectionId, $userId));
+        }
+
+        $response = ['token' => $signedToken];
+        if (isset($userChannelMetaData) && is_array($userChannelMetaData) && count($userChannelMetaData) > 0) {
+            $response['info'] = $userChannelMetaData;
+        }
+
+        return $response;
+    }
+
+    /**
+     * Return the valid authentication response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  mixed  $result
+     * @return mixed
+     */
+    public function validAuthenticationResponse($request, $result)
+    {
+        return $result;
+    }
+
+    /**
+     * Broadcast the given event.
+     *
+     * @param  array  $channels
+     * @param  string  $event
+     * @param  array  $payload
+     * @return void
+     *
+     * @throws \Illuminate\Broadcasting\BroadcastException
+     */
+    public function broadcast($channels, $event, $payload = [])
+    {
+        try {
+            foreach ($this->formatChannels($channels) as $channel) {
+                $this->ably->channels->get($channel)->publish(
+                    $this->buildAblyMessage($event, $payload)
+                );
+            }
+        } catch (AblyException $e) {
+            throw new BroadcastException(
+                sprintf('Ably error: %s', $e->getMessage())
+            );
+        }
+    }
+
+    /**
+     * @param  string  $channelName
+     * @param  string  $token
+     * @param  string  $clientId
+     * @param  string[]  $channelCapability
+     * @return string
+     */
+    public function getSignedToken($channelName, $token, $clientId, $channelCapability = ['*'])
+    {
+        $header = [
+            'typ' => 'JWT',
+            'alg' => 'HS256',
+            'kid' => $this->getPublicToken(),
+        ];
+        // Set capabilities for public channel as per https://ably.com/docs/core-features/authentication#capability-operations
+        $channelClaims = $this->defaultChannelClaims;
+        $serverTimeFn = function () {
+            return self::getServerTime();
+        };
+        if ($token && Utils::isJwtValid($token, $serverTimeFn, $this->getPrivateToken())) {
+            $payload = Utils::parseJwt($token)['payload'];
+            $iat = $payload['iat'];
+            $exp = $payload['exp'];
+            $channelClaims = json_decode($payload['x-ably-capability'], true);
+        } else {
+            $iat = $serverTimeFn();
+            $exp = $iat + $this->tokenExpiry;
+        }
+        if ($channelName) {
+            $channelClaims[$channelName] = $channelCapability;
+        }
+        $claims = [
+            'iat' => $iat,
+            'exp' => $exp,
+            'x-ably-clientId' => $clientId ? strval($clientId) : null,
+            'x-ably-capability' => json_encode($channelClaims),
+        ];
+
+        return Utils::generateJwt($header, $claims, $this->getPrivateToken());
+    }
+
+    /**
+     * Remove prefix from channel name.
+     *
+     * @param  string  $channel
+     * @return string
+     */
+    public function normalizeChannelName($channel)
+    {
+        if ($channel) {
+            if ($this->isPrivateChannel($channel)) {
+                return Str::replaceFirst('private:', '', $channel);
+            }
+            if ($this->isPresenceChannel($channel)) {
+                return Str::replaceFirst('presence:', '', $channel);
+            }
+
+            return Str::replaceFirst('public:', '', $channel);
+        }
+
+        return $channel;
+    }
+
+    /**
+     * Checks if channel is a private channel.
+     *
+     * @param  string  $channel
+     * @return bool
+     */
+    public function isPrivateChannel($channel)
+    {
+        return Str::startsWith($channel, 'private:');
+    }
+
+    /**
+     * Checks if channel is a presence channel.
+     *
+     * @param  string  $channel
+     * @return bool
+     */
+    public function isPresenceChannel($channel)
+    {
+        return Str::startsWith($channel, 'presence:');
+    }
+
+    /**
+     * Checks if channel needs authentication.
+     *
+     * @param  string  $channel
+     * @return bool
+     */
+    public function isGuardedChannel($channel)
+    {
+        return $this->isPrivateChannel($channel) || $this->isPresenceChannel($channel);
+    }
+
+    /**
+     * Format the channel array into an array of strings.
+     *
+     * @param  array  $channels
+     * @return array
+     */
+    public function formatChannels($channels)
+    {
+        return array_map(function ($channel) {
+            $channel = (string) $channel;
+
+            if (Str::startsWith($channel, ['private-', 'presence-'])) {
+                return Str::startsWith($channel, 'private-')
+                    ? Str::replaceFirst('private-', 'private:', $channel)
+                    : Str::replaceFirst('presence-', 'presence:', $channel);
+            }
+
+            return 'public:'.$channel;
+        }, $channels);
+    }
+
+    /**
+     * Build an Ably message object for broadcasting.
+     *
+     * @param  string  $event
+     * @param  array  $payload
+     * @return \Ably\Models\Message
+     */
+    protected function buildAblyMessage($event, $payload = [])
+    {
+        return tap(new AblyMessage, function ($message) use ($event, $payload) {
+            $message->name = $event;
+            $message->data = $payload;
+            $message->connectionKey = data_get($payload, 'socket');
+        });
+    }
+
+    /**
+     * @param  string  $channelName
+     * @param  string  $connectionId
+     * @param  string|null  $userId
+     * @return string
+     */
+    protected function stringify($channelName, $connectionId, $userId = null)
+    {
+        $message = 'channel-name:'.$channelName.' ably-connection-id:'.$connectionId;
+        if ($userId) {
+            return 'user-id:'.$userId.' '.$message;
+        }
+
+        return $message;
+    }
+}

--- a/src/LaravelAblyBroadcasterServiceProvider.php
+++ b/src/LaravelAblyBroadcasterServiceProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Ably\LaravelBroadcaster;
+
+use Ably\AblyRest;
+use Illuminate\Support\Facades\Broadcast;
+use Illuminate\Support\ServiceProvider;
+
+class LaravelAblyBroadcasterServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap the application services.
+     */
+    public function boot()
+    {
+        Broadcast::extend('ably', function ($broadcasting, $config) {
+            return new AblyBroadcaster(new AblyRest($config), $config);
+        });
+    }
+}

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Ably\LaravelBroadcaster;
+
+class Utils
+{
+    // JWT related PHP utility functions
+    /**
+     * @param  string  $jwt
+     * @return array
+     */
+    public static function parseJwt($jwt)
+    {
+        $tokenParts = explode('.', $jwt);
+        $header = json_decode(base64_decode($tokenParts[0]), true);
+        $payload = json_decode(base64_decode($tokenParts[1]), true);
+
+        return ['header' => $header, 'payload' => $payload];
+    }
+
+    /**
+     * @param  array  $headers
+     * @param  array  $payload
+     * @return string
+     */
+    public static function generateJwt($headers, $payload, $key)
+    {
+        $encodedHeaders = self::base64urlEncode(json_encode($headers));
+        $encodedPayload = self::base64urlEncode(json_encode($payload));
+
+        $signature = hash_hmac('SHA256', "$encodedHeaders.$encodedPayload", $key, true);
+        $encodedSignature = self::base64urlEncode($signature);
+
+        return "$encodedHeaders.$encodedPayload.$encodedSignature";
+    }
+
+    /**
+     * @param  string  $jwt
+     * @param  mixed  $timeFn
+     * @return bool
+     */
+    public static function isJwtValid($jwt, $timeFn, $key)
+    {
+        // split the jwt
+        $tokenParts = explode('.', $jwt);
+        $header = $tokenParts[0];
+        $payload = $tokenParts[1];
+        $tokenSignature = $tokenParts[2];
+
+        // check the expiration time - note this will cause an error if there is no 'exp' claim in the jwt
+        $expiration = json_decode(base64_decode($payload))->exp;
+        $isTokenExpired = $expiration <= $timeFn();
+
+        // build a signature based on the header and payload using the secret
+        $signature = hash_hmac('SHA256', $header.'.'.$payload, $key, true);
+        $isSignatureValid = self::base64urlEncode($signature) === $tokenSignature;
+
+        return $isSignatureValid && ! $isTokenExpired;
+    }
+
+    public static function base64urlEncode($str)
+    {
+        return rtrim(strtr(base64_encode($str), '+/', '-_'), '=');
+    }
+}

--- a/tests/AblyBroadcasterTest.php
+++ b/tests/AblyBroadcasterTest.php
@@ -1,0 +1,328 @@
+<?php
+
+namespace Ably\LaravelBroadcaster\Tests;
+
+use Ably\AblyRest;
+use Ably\LaravelBroadcaster\AblyBroadcaster;
+use Ably\LaravelBroadcaster\Utils;
+use Illuminate\Http\Request;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+class AblyBroadcasterTest extends TestCase
+{
+    /**
+     * @var \Ably\LaravelBroadcaster\AblyBroadcaster
+     */
+    public $broadcaster;
+
+    public $ably;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->ably = m::mock(AblyRest::class, ['abcd:efgh']);
+
+        $this->ably->shouldReceive('time')
+                   ->zeroOrMoreTimes()
+                   ->andReturn(time() * 1000); // TODO - make this call at runtime
+
+        $this->broadcaster = m::mock(AblyBroadcaster::class, [$this->ably, []])->makePartial();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+
+    public function testAuthCallValidAuthenticationResponseWithPrivateChannelWhenCallbackReturnTrue()
+    {
+        $this->broadcaster->channel('test', function () {
+            return true;
+        });
+
+        $this->broadcaster->shouldReceive('validAuthenticationResponse')
+                          ->once();
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('private:test', null)
+        );
+    }
+
+    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenCallbackReturnFalse()
+    {
+        $this->expectException(AccessDeniedHttpException::class);
+
+        $this->broadcaster->channel('test', function () {
+            return false;
+        });
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('private:test', null)
+        );
+    }
+
+    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenRequestUserNotFound()
+    {
+        $this->expectException(AccessDeniedHttpException::class);
+
+        $this->broadcaster->channel('test', function () {
+            return true;
+        });
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithoutUserForChannel('private:test', null)
+        );
+    }
+
+    public function testAuthCallValidAuthenticationResponseWithPresenceChannelWhenCallbackReturnAnArray()
+    {
+        $returnData = [1, 2, 3, 4];
+        $this->broadcaster->channel('test', function () use ($returnData) {
+            return $returnData;
+        });
+
+        $this->broadcaster->shouldReceive('validAuthenticationResponse')
+                          ->once();
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('presence:test', null)
+        );
+    }
+
+    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenCallbackReturnNull()
+    {
+        $this->expectException(AccessDeniedHttpException::class);
+
+        $this->broadcaster->channel('test', function () {
+            //
+        });
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('presence:test', null)
+        );
+    }
+
+    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenRequestUserNotFound()
+    {
+        $this->expectException(AccessDeniedHttpException::class);
+
+        $this->broadcaster->channel('test', function () {
+            return [1, 2, 3, 4];
+        });
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithoutUserForChannel('private:test', null)
+        );
+    }
+
+    public function testGenerateAndValidateToken()
+    {
+        $headers = ['alg' => 'HS256', 'typ' => 'JWT'];
+        $payload = ['sub' => '1234567890', 'name' => 'John Doe', 'admin' => true, 'exp' => (time() + 60)];
+        $jwtToken = Utils::generateJwt($headers, $payload, 'efgh');
+
+        $parsedJwt = Utils::parseJwt($jwtToken);
+        self::assertEquals('HS256', $parsedJwt['header']['alg']);
+        self::assertEquals('JWT', $parsedJwt['header']['typ']);
+
+        self::assertEquals('1234567890', $parsedJwt['payload']['sub']);
+        self::assertEquals('John Doe', $parsedJwt['payload']['name']);
+        self::assertEquals(true, $parsedJwt['payload']['admin']);
+
+        $timeFn = function () {
+            return time();
+        };
+        $jwtIsValid = Utils::isJwtValid($jwtToken, $timeFn, 'efgh');
+        self::assertTrue($jwtIsValid);
+    }
+
+    public function testShouldGetSignedToken()
+    {
+        $token = $this->broadcaster->getSignedToken(null, null, 'user123');
+        $parsedToken = Utils::parseJwt($token);
+        $header = $parsedToken['header'];
+        $payload = $parsedToken['payload'];
+
+        self::assertEquals('JWT', $header['typ']);
+        self::assertEquals('HS256', $header['alg']);
+        self::assertEquals('abcd', $header['kid']);
+
+        $expectedCapability = '{"public:*":["subscribe","history","channel-metadata"]}';
+        self::assertEquals($expectedCapability, $payload['x-ably-capability']);
+        self::assertEquals('user123', $payload['x-ably-clientId']);
+
+        self::assertEquals('integer', gettype($payload['iat']));
+        self::assertEquals('integer', gettype($payload['exp']));
+    }
+
+    public function testShouldGetSignedTokenForGivenChannel()
+    {
+        $token = $this->broadcaster->getSignedToken('private:channel', null, 'user123');
+        $parsedToken = Utils::parseJwt($token);
+        $header = $parsedToken['header'];
+        $payload = $parsedToken['payload'];
+
+        self::assertEquals('JWT', $header['typ']);
+        self::assertEquals('HS256', $header['alg']);
+        self::assertEquals('abcd', $header['kid']);
+
+        $expectedCapability = '{"public:*":["subscribe","history","channel-metadata"],"private:channel":["*"]}';
+        self::assertEquals($expectedCapability, $payload['x-ably-capability']);
+        self::assertEquals('user123', $payload['x-ably-clientId']);
+
+        self::assertEquals('integer', gettype($payload['iat']));
+        self::assertEquals('integer', gettype($payload['exp']));
+    }
+
+    public function testShouldHaveUpgradedCapabilitiesForValidToken()
+    {
+        $token = $this->broadcaster->getSignedToken('private:channel', null, 'user123');
+
+        $parsedToken = Utils::parseJwt($token);
+        $payload = $parsedToken['payload'];
+        self::assertEquals('integer', gettype($payload['iat']));
+        self::assertEquals('integer', gettype($payload['exp']));
+        $iat = $payload['iat'];
+        $exp = $payload['exp'];
+
+        $token = $this->broadcaster->getSignedToken('private:channel2', $token, 'user123');
+        $parsedToken = Utils::parseJwt($token);
+        $payload = $parsedToken['payload'];
+        $expectedCapability = '{"public:*":["subscribe","history","channel-metadata"],"private:channel":["*"],"private:channel2":["*"]}';
+        self::assertEquals('user123', $payload['x-ably-clientId']);
+        self::assertEquals($expectedCapability, $payload['x-ably-capability']);
+        self::assertEquals($iat, $payload['iat']);
+        self::assertEquals($exp, $payload['exp']);
+
+        $token = $this->broadcaster->getSignedToken('private:channel3', $token, 'user98');
+        $parsedToken = Utils::parseJwt($token);
+        $payload = $parsedToken['payload'];
+        $expectedCapability = '{"public:*":["subscribe","history","channel-metadata"],"private:channel":["*"],"private:channel2":["*"],"private:channel3":["*"]}';
+        self::assertEquals('user98', $payload['x-ably-clientId']);
+        self::assertEquals($expectedCapability, $payload['x-ably-capability']);
+        self::assertEquals($iat, $payload['iat']);
+        self::assertEquals($exp, $payload['exp']);
+    }
+
+    public function testAuthSignedToken()
+    {
+        $this->broadcaster->channel('test1', function () {
+            return true;
+        });
+        $this->broadcaster->channel('test2', function () {
+            return true;
+        });
+        $this->broadcaster->shouldReceive('validAuthenticationResponse')
+                          ->times(2)
+                          ->andReturn(true, ['userid' => 'user1234', 'info' => 'Hello there']);
+
+        $prevResponse = $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('private:test1', null)
+        );
+        self::assertEquals('string', gettype($prevResponse['token']));
+        $expectedToken = $this->broadcaster->getSignedToken('private:test1', null, 42);
+        self::assertEquals($expectedToken, $prevResponse['token']);
+        self::assertTrue(Utils::isJwtValid($expectedToken, function () {
+            return time();
+        }, 'efgh'));
+
+        $response = $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('presence:test2', $prevResponse['token'])
+        );
+
+        self::assertEquals('string', gettype($response['token']));
+        $expectedToken = $this->broadcaster->getSignedToken('presence:test2', $prevResponse['token'], 42);
+        self::assertEquals($expectedToken, $response['token']);
+        self::assertTrue(Utils::isJwtValid($expectedToken, function () {
+            return time();
+        }, 'efgh'));
+
+        self::assertEquals('array', gettype($response['info']));
+        self::assertEquals(['userid' => 'user1234', 'info' => 'Hello there'], $response['info']);
+    }
+
+    public function testCustomChannelCapability()
+    {
+        $this->broadcaster->channel('test1', function () {
+            return true;
+        });
+
+        $this->broadcaster->shouldReceive('validAuthenticationResponse')
+                          ->times(1)
+                          ->andReturn(['userid' => 'user1234', 'info' => 'Hello there', 'capability' => ['publish', 'subscribe', 'presence']]);
+
+        $response = $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('private:test1', null)
+        );
+        self::assertEquals('string', gettype($response['token']));
+        $expectedToken = $this->broadcaster->getSignedToken('private:test1', null, 42, ['publish', 'subscribe', 'presence']);
+        self::assertEquals($expectedToken, $response['token']);
+        self::assertTrue(Utils::isJwtValid($expectedToken, function () {
+            return time();
+        }, 'efgh'));
+
+        self::assertEquals('array', gettype($response['info']));
+        self::assertEquals(['userid' => 'user1234', 'info' => 'Hello there'], $response['info']);
+    }
+
+    public function testShouldFormatChannels()
+    {
+        $result = $this->broadcaster->formatChannels(['private-hello']);
+        self::assertEquals('private:hello', $result[0]);
+
+        $result = $this->broadcaster->formatChannels(['presence-hello']);
+        self::assertEquals('presence:hello', $result[0]);
+
+        $result = $this->broadcaster->formatChannels(['hello']);
+        self::assertEquals('public:hello', $result[0]);
+    }
+
+    /**
+     * @param  string  $channel
+     * @return \Illuminate\Http\Request
+     */
+    protected function getMockRequestWithUserForChannel($channel, $token)
+    {
+        $request = m::mock(Request::class);
+        $request->channel_name = $channel;
+        $request->token = $token;
+        $request->socket_id = 'abcd.1234';
+
+        $request->shouldReceive('input')
+                ->with('callback', false)
+                ->andReturn(false);
+
+        $user = m::mock('User');
+        $user->shouldReceive('getAuthIdentifierForBroadcasting')
+             ->andReturn(42);
+        $user->shouldReceive('getAuthIdentifier')
+             ->andReturn(42);
+
+        $request->shouldReceive('user')
+                ->andReturn($user);
+
+        return $request;
+    }
+
+    /**
+     * @param  string  $channel
+     * @return \Illuminate\Http\Request
+     */
+    protected function getMockRequestWithoutUserForChannel($channel, $token)
+    {
+        $request = m::mock(Request::class);
+        $request->channel_name = $channel;
+        $request->token = $token;
+        $request->socket_id = 'abcd.1234';
+
+        $request->shouldReceive('user')
+                ->andReturn(null);
+
+        return $request;
+    }
+}


### PR DESCRIPTION
- Created a custom laravel broadcaster as a separate service provider.
- Added laravel supported versions > 6

- [x] Create custom laravel broadcaster.
- [x] Add tests for different laravel versions. 
- [x] Add github workflow with pint styling check and run tests for php versions >=7.2
(https://laravelmagazine.com/blog/run-laravel-pint-as-part-of-your-ci-pipeline-with-github-actions)


Fixes https://github.com/ably/ably-php-laravel/issues/28