### PR TITLE
Optimize request-response time

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,6 +36,10 @@ jobs:
             php-version: 7.3
           - laravel-version: 9.*
             php-version: 7.4
+          - laravel-version: 6.*
+            php-version: 8.1
+          - laravel-version: 7.*
+            php-version: 8.1
 
     name: P${{ matrix.php-version }} - L${{ matrix.laravel-version }}
 

--- a/src/AblyBroadcaster.php
+++ b/src/AblyBroadcaster.php
@@ -59,7 +59,7 @@ class AblyBroadcaster extends Broadcaster
         $this->ably = $ably;
 
         // Local file cache is preferred to avoid sharing serverTimeDiff across different servers
-        $this->serverTimeDiff = Cache::store('file')->remember('ably_server_time_diff', 86400, function() {
+        $this->serverTimeDiff = Cache::store('file')->remember('ably_server_time_diff', 6 * 3600, function() {
             return time() - round($this->ably->time() / 1000);
         });
 

--- a/src/AblyBroadcaster.php
+++ b/src/AblyBroadcaster.php
@@ -50,13 +50,11 @@ class AblyBroadcaster extends Broadcaster
     public function __construct(AblyRest $ably, $config)
     {
         $this->ably = $ably;
-        if (self::$serverTimeDiff == null) {
-            $serverTimeDiff = Cache::remember('server_time_diff', 86400, function() {
-                return time() - round($this->ably->time() / 1000);
-            });
 
-            self::setServerTimeDiff($serverTimeDiff);
-        }
+        self::$serverTimeDiff = Cache::remember('server_time_diff', 86400, function() {
+            return time() - round($this->ably->time() / 1000);
+        });
+
         if (array_key_exists('disable_public_channels', $config) && $config['disable_public_channels']) {
             $this->defaultChannelClaims = ['public:*' => ['channel-metadata']];
         }
@@ -66,15 +64,6 @@ class AblyBroadcaster extends Broadcaster
     }
 
     private static $serverTimeDiff = null;
-
-    /**
-     * @param  int  $timeDiff
-     * @return void
-     */
-    private static function setServerTimeDiff($timeDiff)
-    {
-        self::$serverTimeDiff = $timeDiff;
-    }
 
     /**
      * @return int

--- a/src/AblyBroadcaster.php
+++ b/src/AblyBroadcaster.php
@@ -41,6 +41,13 @@ class AblyBroadcaster extends Broadcaster
     ];
 
     /**
+     * Used for storing the difference in seconds between system time and Ably server time
+     *
+     * @var int
+     */
+    private $serverTimeDiff;
+
+    /**
      * Create a new broadcaster instance.
      *
      * @param  \Ably\AblyRest  $ably
@@ -63,8 +70,6 @@ class AblyBroadcaster extends Broadcaster
             $this->tokenExpiry = $config['token_expiry'];
         }
     }
-
-    private $serverTimeDiff;
 
     /**
      * @return int

--- a/src/AblyBroadcaster.php
+++ b/src/AblyBroadcaster.php
@@ -51,7 +51,7 @@ class AblyBroadcaster extends Broadcaster
     {
         $this->ably = $ably;
 
-        self::$serverTimeDiff = Cache::remember('server_time_diff', 86400, function() {
+        $this->serverTimeDiff = Cache::remember('server_time_diff', 86400, function() {
             return time() - round($this->ably->time() / 1000);
         });
 
@@ -63,15 +63,15 @@ class AblyBroadcaster extends Broadcaster
         }
     }
 
-    private static $serverTimeDiff = null;
+    private $serverTimeDiff;
 
     /**
      * @return int
      */
-    private static function getServerTime()
+    private function getServerTime()
     {
-        if (self::$serverTimeDiff != null) {
-            return time() - self::$serverTimeDiff;
+        if ($this->serverTimeDiff != null) {
+            return time() - $this->serverTimeDiff;
         }
 
         return time();
@@ -202,7 +202,7 @@ class AblyBroadcaster extends Broadcaster
         // Set capabilities for public channel as per https://ably.com/docs/core-features/authentication#capability-operations
         $channelClaims = $this->defaultChannelClaims;
         $serverTimeFn = function () {
-            return self::getServerTime();
+            return $this->getServerTime();
         };
         if ($token && Utils::isJwtValid($token, $serverTimeFn, $this->getPrivateToken())) {
             $payload = Utils::parseJwt($token)['payload'];

--- a/src/AblyBroadcaster.php
+++ b/src/AblyBroadcaster.php
@@ -59,7 +59,7 @@ class AblyBroadcaster extends Broadcaster
         $this->ably = $ably;
 
         // Local file cache is preferred to avoid sharing serverTimeDiff across different servers
-        $this->serverTimeDiff = Cache::store('file')->remember('server_time_diff', 86400, function() {
+        $this->serverTimeDiff = Cache::store('file')->remember('ably_server_time_diff', 86400, function() {
             return time() - round($this->ably->time() / 1000);
         });
 

--- a/src/AblyBroadcaster.php
+++ b/src/AblyBroadcaster.php
@@ -51,7 +51,8 @@ class AblyBroadcaster extends Broadcaster
     {
         $this->ably = $ably;
 
-        $this->serverTimeDiff = Cache::remember('server_time_diff', 86400, function() {
+        // Local file cache is preferred to avoid sharing serverTimeDiff across different servers
+        $this->serverTimeDiff = Cache::store('file')->remember('server_time_diff', 86400, function() {
             return time() - round($this->ably->time() / 1000);
         });
 

--- a/tests/AblyBroadcasterTest.php
+++ b/tests/AblyBroadcasterTest.php
@@ -9,7 +9,6 @@ use Ably\LaravelBroadcaster\Utils;
 use Ably\Utils\Miscellaneous;
 use Illuminate\Http\Request;
 use Mockery as m;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class AblyBroadcasterTest extends TestCase

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ably\LaravelBroadcaster\Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Orchestra\Testbench\Concerns\CreatesApplication;
+
+abstract class TestCase extends BaseTestCase
+{
+    use CreatesApplication;
+}


### PR DESCRIPTION
1. **Problem**
- For every client network request, Laravel used to make network request to `Ably` for getting `server time` . 
- This is due to a lack of laravel support to persist static variables across multiple requests.

2. **Solution**
- `Server time diff` is saved in local file cache.
-  So only on the first request, time is fetched and then reused for subsequent requests.

3. **Result**
- Reduced response time depending on latency to Ably servers. 
- In my case, it was reduced from `350ms` to `150ms` on page loads where Ably server time was cached.

Fixed #16 