### PR TITLE
Remove "socket" key from message data

### DIFF
--- a/src/AblyBroadcaster.php
+++ b/src/AblyBroadcaster.php
@@ -9,6 +9,7 @@ use Illuminate\Broadcasting\Broadcasters\Broadcaster;
 use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
+use Illuminate\Support\Arr;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class AblyBroadcaster extends Broadcaster
@@ -317,10 +318,12 @@ class AblyBroadcaster extends Broadcaster
      */
     protected function buildAblyMessage($event, $payload = [])
     {
-        return tap(new AblyMessage, function ($message) use ($event, $payload) {
+        $socket = Arr::pull($payload, 'socket');
+
+        return tap(new AblyMessage, function ($message) use ($event, $payload, $socket) {
             $message->name = $event;
             $message->data = $payload;
-            $message->connectionKey = data_get($payload, 'socket');
+            $message->connectionKey = $socket;
         });
     }
 

--- a/tests/AblyBroadcasterTest.php
+++ b/tests/AblyBroadcasterTest.php
@@ -360,7 +360,6 @@ class AblyBroadcasterExposed extends AblyBroadcaster
     }
 }
 
-
 class HttpMock extends Http
 {
     public $lastUrl;

--- a/tests/AblyBroadcasterTest.php
+++ b/tests/AblyBroadcasterTest.php
@@ -343,11 +343,11 @@ class AblyBroadcasterTest extends TestCase
         $broadcaster = m::mock(AblyBroadcasterExposed::class, [$this->ably, []])->makePartial();
 
         $payload = [
-            "foo" => "bar",
-            "socket" => null
+            'foo' => 'bar',
+            'socket' => null
         ];
 
-        $message = $broadcaster->buildAblyMessage("testEvent", $payload);
+        $message = $broadcaster->buildAblyMessage('testEvent', $payload);
         self::assertArrayNotHasKey('socket', $message->data);
     }
 }

--- a/tests/AblyBroadcasterTest.php
+++ b/tests/AblyBroadcasterTest.php
@@ -337,6 +337,27 @@ class AblyBroadcasterTest extends TestCase
         $expectedLaravelHeader = 'ably-php/'.\Ably\Defaults::LIB_VERSION.' '.'php/'.Miscellaneous::getNumeric(phpversion()).' laravel-broadcaster/'. AblyBroadcaster::LIB_VERSION;
         $this->assertcontains( 'Ably-Agent: '.$expectedLaravelHeader, $ably->http->lastHeaders, 'Expected Laravel broadcaster header in HTTP request' );
     }
+
+    public function testPayloadShouldNotIncludeSocketKey()
+    {
+        $broadcaster = m::mock(AblyBroadcasterExposed::class, [$this->ably, []])->makePartial();
+
+        $payload = [
+            "foo" => "bar",
+            "socket" => null
+        ];
+
+        $message = $broadcaster->buildAblyMessage("testEvent", $payload);
+        self::assertArrayNotHasKey('socket', $message->data);
+    }
+}
+
+class AblyBroadcasterExposed extends AblyBroadcaster
+{
+    public function buildAblyMessage($event, $payload = [])
+    {
+        return parent::buildAblyMessage($event, $payload);
+    }
 }
 
 


### PR DESCRIPTION
Noticed that all messages being sent form Laravel broadcast events included an extra socket key in the message data. Depending on the structure of data I was sending from Laravel (and in turn receiving in the client) this extra attribute could cause the data structure to be different from what was expected and cause errors.

![Screenshot 2022-11-22 at 8 22 39 pm](https://user-images.githubusercontent.com/285668/203316446-9418dbdc-3f99-4e65-a068-edfdad1d19b2.png)

It appears that this socket value comes from the InteractsWithSockets trait which is included by default in all new events created by artisan so this should be handed as the default. Using the Pusher implementation as inspiration it appears they are handling this by pulling the socket key from the payload array before building up the message. 

https://github.com/illuminate/broadcasting/blob/68939fc64fb3d553e066dbfcee7c0d835d7d24bc/Broadcasters/PusherBroadcaster.php#L151

This pull request implements the same logic that is used by the Pusher implementation. The Arr::pull function returns a default value of null which is the same as data_get function currently used.

