### PR TITLE
Removed non-documented capability key check 

### DIFF
--- a/src/AblyBroadcaster.php
+++ b/src/AblyBroadcaster.php
@@ -133,9 +133,6 @@ class AblyBroadcaster extends Broadcaster
                 if (is_array($userChannelMetaData) && array_key_exists('ably-capability', $userChannelMetaData)) {
                     $guardedChannelCapability = $userChannelMetaData['ably-capability'];
                     unset($userChannelMetaData['ably-capability']);
-                } else if (is_array($userChannelMetaData) && array_key_exists('capability', $userChannelMetaData)) { // deprecated, will be removed in future versions
-                    $guardedChannelCapability = $userChannelMetaData['capability'];
-                    unset($userChannelMetaData['capability']);
                 }
             } catch (\Exception $e) {
                 throw new AccessDeniedHttpException('Access denied, '.$this->stringify($channelName, $connectionId, $userId), $e);


### PR DESCRIPTION
Following are the reasons to remove the check
1. This `check` is not documented since the library was published on [Laravel Packagist](https://packagist.org/packages/ably/laravel-broadcaster), so no one should be using it as of now. 
2. Developers using the `capability` key for other purposes in case of presence channels will break the auth flow. 
3. Since the library is getting more popular+downloads, we should be removing the unnecessary check since it's getting introduced as a bug (we already recommend using `ably-capability` as a key), instead of providing any real value for future downloads.