### PR TITLE
[ECO-5208] Support laravel 12

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
-        laravel-version: [6.*, 7.*, 8.*, 9.*, 10.*, 11.*]
+        php-version: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
+        laravel-version: [6.*, 7.*, 8.*, 9.*, 10.*, 11.*, 12.*]
         include:
           - laravel-version: 6.*
             testbench: 4.*
@@ -31,8 +31,20 @@ jobs:
             testbench: 8.*
           - laravel-version: 11.*
             testbench: 9.*
+          - laravel-version: 12.*
+            testbench: 10.*
             
         exclude:
+          - laravel-version: 12.*
+            php-version: 7.2
+          - laravel-version: 12.*
+            php-version: 7.3
+          - laravel-version: 12.*
+            php-version: 7.4
+          - laravel-version: 12.*
+            php-version: 8.0
+          - laravel-version: 12.*
+            php-version: 8.1
           - laravel-version: 11.*
             php-version: 7.2
           - laravel-version: 11.*
@@ -67,6 +79,14 @@ jobs:
             php-version: 8.2
           - laravel-version: 7.*
             php-version: 8.2
+          - laravel-version: 6.*
+            php-version: 8.3
+          - laravel-version: 7.*
+            php-version: 8.3
+          - laravel-version: 6.*
+            php-version: 8.4
+          - laravel-version: 7.*
+            php-version: 8.4
 
     name: P${{ matrix.php-version }} - L${{ matrix.laravel-version }}
 

--- a/README.md
+++ b/README.md
@@ -126,10 +126,11 @@ npm run dev
         ],
 ```
 
-**3. Update token expiry. Default: 3600 seconds (1 hr)**
+**3. Update token expiry. Default: 28800 seconds (8 hrs)**
+- Default expiry set to 8 hrs in order to reduce CPU workload for auth requests. Check [discussion](https://github.com/ably/laravel-broadcaster/issues/55#issuecomment-2582845145).
 - Set `ABLY_TOKEN_EXPIRY` in **.env** file.
 ```dotenv
-    ABLY_TOKEN_EXPIRY=21600
+    ABLY_TOKEN_EXPIRY=43200
 ```
 - Update ably section under `config/broadcasting.php` with
 ```php

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "ably/ably-php": "^1.1",
-        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
+        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
         "ext-json" : "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5 || ^9.5 || ^10.0 || ^11.0",
-        "orchestra/testbench": "4.* || 8.* || 9.*"
+        "phpunit/phpunit": "^8.5 || ^9.5 || ^10.0 || ^11.0 || ^12.0",
+        "orchestra/testbench": "4.* || 8.* || 9.* || 10.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/AblyBroadcaster.php
+++ b/src/AblyBroadcaster.php
@@ -27,9 +27,9 @@ class AblyBroadcaster extends Broadcaster
      * Used for setting expiry of issues tokens.
      *
      * @var int|mixed
-     * @default 1 hr
+     * @default 8 hr
      */
-    private $tokenExpiry = 3600;
+    private $tokenExpiry = 28800;
 
     /**
      * Public channel capabilities. By default, all public channels are given subscribe, history and channel-metadata access.


### PR DESCRIPTION
- Fixed #58 
- Increased token expiry to 8 hrs in order to reduce CPU workload, check https://github.com/ably/laravel-broadcaster/issues/55


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated token expiry settings in the documentation, extending the default token lifetime from 1 hour to 8 hours along with revised environment configuration examples.
- **Chores**
  - Improved compatibility and robustness by updating dependency versions and refining continuous integration settings to support newer PHP and framework releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->