### PR TITLE
[DX-971] Support laravel 13

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,8 +35,9 @@ jobs:
             testbench: 10.*
           - laravel-version: 13.*
             testbench: 11.*
-            
+
         exclude:
+          # Laravel 13 requires PHP >= 8.3
           - laravel-version: 13.*
             php-version: 7.2
           - laravel-version: 13.*
@@ -49,6 +50,7 @@ jobs:
             php-version: 8.1
           - laravel-version: 13.*
             php-version: 8.2
+          # Laravel 12 requires PHP >= 8.2
           - laravel-version: 12.*
             php-version: 7.2
           - laravel-version: 12.*
@@ -59,6 +61,7 @@ jobs:
             php-version: 8.0
           - laravel-version: 12.*
             php-version: 8.1
+          # Laravel 11 requires PHP >= 8.2
           - laravel-version: 11.*
             php-version: 7.2
           - laravel-version: 11.*
@@ -69,6 +72,7 @@ jobs:
             php-version: 8.0
           - laravel-version: 11.*
             php-version: 8.1
+          # Laravel 10 requires PHP >= 8.1
           - laravel-version: 10.*
             php-version: 7.2
           - laravel-version: 10.*
@@ -77,14 +81,17 @@ jobs:
             php-version: 7.4
           - laravel-version: 10.*
             php-version: 8.0
+          # Laravel 9 requires PHP >= 8.0
+          - laravel-version: 9.*
+            php-version: 7.2
+          - laravel-version: 9.*
+            php-version: 7.3
+          - laravel-version: 9.*
+            php-version: 7.4
+          # Laravel 8 requires PHP >= 7.3
           - laravel-version: 8.*
             php-version: 7.2
-          - laravel-version: 9.*
-            php-version: 7.2
-          - laravel-version: 9.*
-            php-version: 7.3
-          - laravel-version: 9.*
-            php-version: 7.4
+          # Laravel 6/7 max PHP 8.0
           - laravel-version: 6.*
             php-version: 8.1
           - laravel-version: 7.*
@@ -105,16 +112,36 @@ jobs:
             php-version: 8.5
           - laravel-version: 7.*
             php-version: 8.5
+          # Laravel 8 max PHP 8.1
+          - laravel-version: 8.*
+            php-version: 8.2
+          - laravel-version: 8.*
+            php-version: 8.3
+          - laravel-version: 8.*
+            php-version: 8.4
           - laravel-version: 8.*
             php-version: 8.5
+          # Laravel 9 max PHP 8.2
           - laravel-version: 9.*
+            php-version: 8.3
+          - laravel-version: 9.*
+            php-version: 8.4
+          - laravel-version: 9.*
+            php-version: 8.5
+          # Laravel 10 max PHP 8.3
+          - laravel-version: 10.*
+            php-version: 8.4
+          - laravel-version: 10.*
+            php-version: 8.5
+          # Laravel 11 max PHP 8.4
+          - laravel-version: 11.*
             php-version: 8.5
 
     name: P${{ matrix.php-version }} - L${{ matrix.laravel-version }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
@@ -123,6 +150,9 @@ jobs:
 
       - name: Validate composer.json and composer.lock
         run: composer validate
+
+      - name: Allow installing packages with security advisories
+        run: composer config audit.block-insecure false
 
       - name: Install dependencies
         run: |
@@ -139,7 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     name: PHP Linting (Pint)
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: "laravel-pint"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
-        laravel-version: [6.*, 7.*, 8.*, 9.*, 10.*, 11.*, 12.*]
+        php-version: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
+        laravel-version: [6.*, 7.*, 8.*, 9.*, 10.*, 11.*, 12.*, 13.*]
         include:
           - laravel-version: 6.*
             testbench: 4.*
@@ -33,8 +33,22 @@ jobs:
             testbench: 9.*
           - laravel-version: 12.*
             testbench: 10.*
+          - laravel-version: 13.*
+            testbench: 11.*
             
         exclude:
+          - laravel-version: 13.*
+            php-version: 7.2
+          - laravel-version: 13.*
+            php-version: 7.3
+          - laravel-version: 13.*
+            php-version: 7.4
+          - laravel-version: 13.*
+            php-version: 8.0
+          - laravel-version: 13.*
+            php-version: 8.1
+          - laravel-version: 13.*
+            php-version: 8.2
           - laravel-version: 12.*
             php-version: 7.2
           - laravel-version: 12.*
@@ -87,6 +101,14 @@ jobs:
             php-version: 8.4
           - laravel-version: 7.*
             php-version: 8.4
+          - laravel-version: 6.*
+            php-version: 8.5
+          - laravel-version: 7.*
+            php-version: 8.5
+          - laravel-version: 8.*
+            php-version: 8.5
+          - laravel-version: 9.*
+            php-version: 8.5
 
     name: P${{ matrix.php-version }} - L${{ matrix.laravel-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "ably/ably-php": "^1.1",
-        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
         "ext-json" : "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 || ^9.5 || ^10.0 || ^11.0 || ^12.0",
-        "orchestra/testbench": "4.* || 8.* || 9.* || 10.*"
+        "orchestra/testbench": "4.* || 8.* || 9.* || 10.* || 11.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Fixes https://ably.atlassian.net/browse/DX-971
1. Updated composer to add support for laravel 13 and related testsuite dependencies
2. Updated CI workflow to run broadcaster tests with laravel 13 and supported versions of PHP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for Laravel 13.* and PHP 8.5.
  * Updated testing framework compatibility to Testbench 11.*.
  * Expanded CI matrix with additional PHP/Laravel combinations and refined exclusions to enforce per-version PHP requirements.
  * Relaxed dependency constraints to permit illuminate/support ^13.0 and orchestra/testbench 11.*.
  * Upgraded CI checkout action and enabled composer setting to permit installing packages with security advisories; applied to linting workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->