### PR TITLE
ci: GHA workflow security cleanup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -142,6 +142,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
@@ -172,6 +174,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          persist-credentials: false
       - name: "laravel-pint"
         uses: aglipanci/laravel-pint-action@1.0.0
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -145,12 +145,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Set up PHP ${{ matrix.php-version }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: ${{ matrix.php-version }}
 
@@ -180,11 +180,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 2
           persist-credentials: false
       - name: "laravel-pint"
-        uses: aglipanci/laravel-pint-action@1.0.0
+        uses: aglipanci/laravel-pint-action@643466ad03b726047b3c78b531be5ec7835429ff # 1.0.0
         with:
           preset: laravel

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,11 +8,15 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   check:
 
     runs-on: ubuntu-latest
     needs: phplint
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -170,6 +174,8 @@ jobs:
   phplint:
     runs-on: ubuntu-latest
     name: PHP Linting (Pint)
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -161,9 +161,12 @@ jobs:
         run: composer config audit.block-insecure false
 
       - name: Install dependencies
+        env:
+          LARAVEL_VERSION: ${{ matrix.laravel-version }}
+          TESTBENCH_VERSION: ${{ matrix.testbench }}
         run: |
-          composer require "laravel/framework:${{ matrix.laravel-version }}" --no-interaction --no-update
-          composer require --dev "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${LARAVEL_VERSION}" --no-interaction --no-update
+          composer require --dev "orchestra/testbench:${TESTBENCH_VERSION}" --no-interaction --no-update
           composer install --prefer-dist --no-progress
 
       # the test script is configured in composer.json.


### PR DESCRIPTION
Routine hygiene pass over the GitHub Actions workflow in this repo, addressing findings from a workflow security audit. Changes are split into four commits, one per finding type:

 - Disable credential persistence on actions/checkout steps so the default GITHUB_TOKEN is not left in the local git config after checkout.
 - Scope each job's permissions explicitly: top-level permissions: {}, with each job granted only the GITHUB_TOKEN scopes it actually needs (contents: read).
 - Move workflow-context expansions (${{ matrix.laravel-version }}, ${{ matrix.testbench }}) out of run: shell source and into env: bindings.
 - Pin all third-party actions to commit SHAs (with the tag preserved as a comment) so an upstream tag move can't silently change what runs in CI.

No behavioural changes intended — the workflow runs the same checks against the same inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal CI/CD workflow configurations with enhanced security measures and pinned dependencies to specific versions for improved stability and reproducibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ably/laravel-broadcaster/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->